### PR TITLE
Add subjective exercise component

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -89,6 +89,38 @@
       </fieldset>
       </form>
     </template>
+    <template id="exercise-subjective">
+      <style>
+        button {
+          cursor: pointer;
+        }
+        .btn {
+          padding: 5px 20px;
+          font-size: 16px;
+          border-radius: 30px;
+          border: 1px solid gray;
+          transition: all ease-in-out 0.1s;
+        }
+        .container {
+          margin-top: 10px;
+        }
+        textarea {
+          width: 100%;
+          resize: vertical;
+        }
+      </style>
+      <form>
+        <fieldset>
+          <legend style="padding: 0 5px" class="legend">Default Question</legend>
+          <div class="container">
+            <textarea rows="4"></textarea>
+          </div>
+          <button class="btn btn-submit" type="submit">
+            Submit Answer
+          </button>
+        </fieldset>
+      </form>
+    </template>
     {% block body %} {% endblock %}
   </body>
   <script src="{{ url_for ('static', filename='jquery.js') }}"></script>

--- a/templates/components.html
+++ b/templates/components.html
@@ -1,3 +1,8 @@
 {% extends 'base_page.html' %} {% block body %}
 <exercise-single-choices style="width: 100%;" choices="aaa,vvv"></exercise-single-choices>
+<exercise-subjective
+  style="width: 100%;"
+  exercise_name="exercise_subjective_1"
+  exercise_label="Write your answer"
+></exercise-subjective>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `exercise-subjective` web component for textarea-based exercises
- provide base template and example usage

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689842d800c8832c9a7ad9a4239a9562