### PR TITLE
feat: extract exercise message component

### DIFF
--- a/components/test.html
+++ b/components/test.html
@@ -1,19 +1,5 @@
-<template id="exercise-single-choices">
-  <script>
-    
-  </script>
+<template id="exercise-message">
   <style>
-    button {
-      cursor: pointer;
-    }
-    .btn {
-      padding: 5px 20px;
-      font-size: 16px;
-      border-radius: 30px;
-      border: 1px solid gray;
-      transition: all ease-in-out 0.1s;
-    }
-
     .message-err {
       padding: 5px 20px;
       font-size: 16px;
@@ -30,13 +16,56 @@
       background-color: rgb(159, 247, 137);
     }
 
+    .message-reason {
+      background-color: rgb(207, 207, 207);
+    }
+
+    .container {
+      margin-top: 10px;
+    }
+
+    .reason-text {
+      padding: 20px;
+    }
+  </style>
+  <div>
+    <div style="position: relative; text-wrap: nowrap">
+      <div
+        class="message message-success"
+        style="position: absolute; visibility: hidden"
+      >
+        Correct
+      </div>
+      <div
+        class="message message-err"
+        style="position: absolute; visibility: hidden"
+      >
+        Wrong Answer
+      </div>
+    </div>
+    <div class="message-reason container"></div>
+  </div>
+</template>
+
+<template id="exercise-single-choices">
+  <script>
+
+  </script>
+  <style>
+    button {
+      cursor: pointer;
+    }
+    .btn {
+      padding: 5px 20px;
+      font-size: 16px;
+      border-radius: 30px;
+      border: 1px solid gray;
+      transition: all ease-in-out 0.1s;
+    }
+
     .result-container {
       display: flex;
       gap: 10px;
-    }
-
-    .message-reason {
-      background-color: rgb(207, 207, 207);
     }
 
     .container {
@@ -48,10 +77,6 @@
       margin-right: 20px;
       transform: scale(150%);
     }
-
-    .reason-text {
-      padding: 20px;
-    }
   </style>
   <form>
     <fieldset>
@@ -59,22 +84,8 @@
       <div style="padding: 20px" class="container"></div>
       <div class="result-container">
         <button class="btn btn-submit" type="submit">Submit Answer</button>
-        <div style="position: relative; text-wrap: nowrap">
-          <div
-            class="message message-success"
-            style="position: absolute; visibility: hidden"
-          >
-            Correct
-          </div>
-          <div
-            class="message message-err"
-            style="position: absolute; visibility: hidden"
-          >
-            Wrong Answer
-          </div>
-        </div>
       </div>
-      <div class="message-reason container"></div>
+      <exercise-message></exercise-message>
     </fieldset>
   </form>
 </template>

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,19 +11,8 @@
     />
   </head>
   <body class="page-content page-nav-hidden" id="page-nav">
-    <template id="exercise-single-choices">
+    <template id="exercise-message">
       <style>
-        button {
-          cursor: pointer;
-        }
-        .btn {
-          padding: 5px 20px;
-          font-size: 16px;
-          border-radius: 30px;
-          border: 1px solid gray;
-          transition: all ease-in-out 0.1s;
-        }
-
         .message-err {
           padding: 5px 20px;
           font-size: 16px;
@@ -40,15 +29,49 @@
           background-color: rgb(159, 247, 137);
         }
 
+        .message-reason {
+          background-color: rgb(207, 207, 207);
+        }
+
+        .container {
+          margin-top: 10px;
+        }
+
+        .reason-text {
+          padding: 20px;
+        }
+      </style>
+      <div>
+        <div style="position: relative; text-wrap: nowrap">
+          <div class="message message-success" style="position: absolute; visibility: hidden">
+            Correct
+          </div>
+          <div class="message message-err" style="position: absolute; visibility: hidden">
+            Wrong Answer
+          </div>
+        </div>
+        <div class="message-reason container"></div>
+      </div>
+    </template>
+
+    <template id="exercise-single-choices">
+      <style>
+        button {
+          cursor: pointer;
+        }
+        .btn {
+          padding: 5px 20px;
+          font-size: 16px;
+          border-radius: 30px;
+          border: 1px solid gray;
+          transition: all ease-in-out 0.1s;
+        }
+
         .result-container {
           display: flex;
           gap: 10px;
         }
 
-        .message-reason {
-          background-color: rgb(207, 207, 207);
-        }
-        
         .container {
           margin-top: 10px;
         }
@@ -58,12 +81,6 @@
           margin-right: 20px;
           transform: scale(150%);
         }
-
-        .reason-text {
-          padding: 20px;
-        }
-
-        
       </style>
       <form>
         <fieldset>
@@ -76,16 +93,8 @@
           >
             Submit Answer
           </button>
-          <div style="position: relative;text-wrap: nowrap">
-            <div class="message message-success" style="position: absolute;visibility: hidden;">
-            Correct
-            </div>
-            <div class="message message-err" style="position: absolute;visibility: hidden;">
-            Wrong Answer
-            </div>
-          </div>
         </div>
-        <div class="message-reason container"></div>
+        <exercise-message></exercise-message>
       </fieldset>
       </form>
     </template>


### PR DESCRIPTION
## Summary
- create reusable exercise-message component encapsulating status and reason display
- refactor quiz template and logic to use exercise-message

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68996e22ac5c832ca546c51b24fe14b6